### PR TITLE
docs: command typo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -36,4 +36,4 @@ See `UserConfig` in [src/types.ts](src/types.ts) for more information.
 ### 🧞 Commands
 
 - `npx toybox`: Start preview of toybox.
-- `npm toybox build`: Build a static version of toybox. The new files will be placed in `toybox_dist`
+- `npx toybox build`: Build a static version of toybox. The new files will be placed in `toybox_dist`


### PR DESCRIPTION
Found tiny typo when reading readme file.