### PR TITLE
fix: release new semantic version

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -105,5 +105,5 @@ export const story: Story = {
 
 ### 🧞 Commands
 
-- `npx toybox`: Start preview of toybox.
+- `npx toybox`: Start a preview of toybox.
 - `npx toybox build`: Build a static version of toybox. The new files will be placed in `toybox_dist`


### PR DESCRIPTION
It seems like #7 didn't release a new version probly due to the naming of the commit.