### PR TITLE
fix: add new story button for documentation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -43,14 +43,19 @@ export const story: Story = {
   header: {
     // Title of story
     title: 'Button',
-    // Two different types of buttons are available, github or figma
+    // Three different types of buttons are available, github, figma or designsystem.
     // Url for github type is optional, we will try to generate a url based on the component name. You could also give it a value if you prefer.
     // Figma url is a link to the design of the component.
+    // designsystem is our documentation helper that gives developers more detailed documentation of the component.
     storyButtons: [
       { type: 'github' },
       {
         type: 'figma',
         url: 'https://www.figma.com/file/cqWQxzXlhuLc5SRXemxy4F/Kivra-Style-Guide?node-id=20746%3A39897',
+      },
+      {
+        type: 'designsystem'
+        url: 'https://design.kivra.com/07ebba6a7/p/91f64e-intro',
       },
     ],
     // Description of the component

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,7 +21,7 @@ export interface StoryRoute {
   component: StoryComponent;
 }
 
-type StoryButtonTypes = "github" | "figma";
+type StoryButtonTypes = "github" | "figma" | "designsystem";
 
 export interface StoryButton {
   type: StoryButtonTypes;

--- a/src/webapp/layout/story/story-button/StoryButton.story.tsx
+++ b/src/webapp/layout/story/story-button/StoryButton.story.tsx
@@ -11,15 +11,22 @@ export const story: Story = {
       name: 'Github',
       center: true,
       render() {
-        return <StoryHeaderButton type="github" url="https://google.com" />
+        return <StoryHeaderButton type="github" url="https://github.com" />
       }
     },
     {
-      name: 'Figma ',
+      name: 'Figma',
       center: true,
       render() {
-        return <StoryHeaderButton type="figma" url="https://google.com" />
+        return <StoryHeaderButton type="figma" url="https://figma.com" />
       }
-    }
+    },
+    {
+      name: 'Kivra Design System',
+      center: true,
+      render() {
+        return <StoryHeaderButton type="designsystem" url="https://design.kivra.com/" />
+      }
+    },
   ]
 }

--- a/src/webapp/layout/story/story-button/StoryButton.tsx
+++ b/src/webapp/layout/story/story-button/StoryButton.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import { Body } from '../atom/typo';
 
 export interface Props {
-  type: 'github' | 'figma';
+  type: 'github' | 'figma' | 'designsystem';
   url: string;
 }
 
@@ -17,15 +17,25 @@ export const StoryHeaderButton: React.FC<Props> = ({ type, url }) => {
         description="GitHub"
       />
     );
+  } else if (type === 'designsystem') {
+    return (
+      <StoryButton
+        url={url}
+        imgSrc="https://static.kivra.com/assets/logo/kivra-symbol-logo.svg"
+        title="View documentation"
+        description="Kivra Design System"
+      />
+    );
+  } else {
+    return (
+      <StoryButton
+        url={url}
+        imgSrc="https://static.kivra.com/assets/logo/figma-logo.svg"
+        title="View guidelines"
+        description="Figma"
+      />
+    );
   }
-  return (
-    <StoryButton
-      url={url}
-      imgSrc="https://static.kivra.com/assets/logo/figma-logo.svg"
-      title="View guidelines"
-      description="Figma"
-    />
-  );
 };
 
 const StoryButton = ({


### PR DESCRIPTION
Adds a new documentation story button that will link into pages from https://design.kivra.com/, meant to give more detailed information about a component usuage for web.

<img width="338" alt="Skärmavbild 2022-09-02 kl  15 22 09" src="https://user-images.githubusercontent.com/77273035/188155111-72da25bc-ad1b-4f0d-9f74-c423ebe7ca89.png">
