### PR TITLE
fix: fixed the mobile view

### DIFF
--- a/src/cli/util.ts
+++ b/src/cli/util.ts
@@ -10,7 +10,7 @@ export const htmlContent = (config: Config) => {
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1.0, user-scalable=yes, maximum-scale=5.0" />
     <link
       rel="icon"
       href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>${config.emojiIcon}</text></svg>"

--- a/src/webapp/ModuleComponent.tsx
+++ b/src/webapp/ModuleComponent.tsx
@@ -85,4 +85,7 @@ const MainInnerWrapper = styled("div")({
   maxWidth: "1280px",
   padding: "0 40px",
   margin: "0 auto",
+  "@media (max-width: 960px)": {
+    padding: "0 20px",
+  },
 });

--- a/src/webapp/layout/Main.tsx
+++ b/src/webapp/layout/Main.tsx
@@ -31,7 +31,7 @@ export function Main({ routes, children }: Props) {
       {(!isSmallScreen || hamburgerOpen) && (
         <Navbar onItemClick={() => setHamburgerOpen(false)} routes={routes} />
       )}
-      {hamburgerOpen && <Overlay />}
+      {hamburgerOpen && <Overlay onClick={() => setHamburgerOpen(false)} />}
       <MainContent>{children}</MainContent>
     </Container>
   );
@@ -73,9 +73,10 @@ const MainContent = styled.main`
 `;
 
 const Overlay = styled.div`
-  inset: 0px;
   z-index: 1074;
   position: absolute;
+  width: 100%;
+  height: 100vh;
   background-color: rgba(0, 0, 0, 0.5);
   opacity: 1;
   transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;

--- a/src/webapp/layout/Main.tsx
+++ b/src/webapp/layout/Main.tsx
@@ -1,6 +1,9 @@
-import styled from '@emotion/styled';
-import type { NestedStoryRoute } from '../routeLoader';
-import { Navbar } from './Navbar';
+import styled from "@emotion/styled";
+import { useMediaQuery } from "@mantine/hooks";
+import { Burger as MantineBurger } from "@mantine/core";
+import { useEffect, useState } from "react";
+import type { NestedStoryRoute } from "../routeLoader";
+import { Navbar } from "./Navbar";
 
 interface Props {
   routes: NestedStoryRoute;
@@ -8,13 +11,41 @@ interface Props {
 }
 
 export function Main({ routes, children }: Props) {
+  const isSmallScreen = useMediaQuery("(max-width: 960px)");
+  const [hamburgerOpen, setHamburgerOpen] = useState(false);
+
+  useEffect(() => {
+    if (!isSmallScreen) {
+      return setHamburgerOpen(false);
+    }
+  }, [isSmallScreen]);
   return (
     <Container>
-      <Navbar routes={routes} />
+      <Burger
+        opened={hamburgerOpen}
+        onClick={() => setHamburgerOpen(!hamburgerOpen)}
+      />
+      {(!isSmallScreen || hamburgerOpen) && (
+        <Navbar onItemClick={() => setHamburgerOpen(false)} routes={routes} />
+      )}
       <MainContent>{children}</MainContent>
     </Container>
   );
 }
+
+const Burger = styled(MantineBurger)({
+  display: "none",
+  "@media (max-width: 960px)": {
+    zIndex: 100,
+    position: "absolute",
+    top: "24px",
+    right: "24px",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "flex-end",
+    padding: "0px",
+  },
+});
 
 const Container = styled.div`
   display: grid;
@@ -23,10 +54,11 @@ const Container = styled.div`
   gap: 0px 0px;
   grid-auto-flow: row;
   grid-template-areas:
-    'Header Header'
-    'Menu Main';
+    "Header Header"
+    "Menu Main";
   min-height: 100vh;
 `;
 const MainContent = styled.main`
   grid-area: Main;
+  overflow: hidden;
 `;

--- a/src/webapp/layout/Main.tsx
+++ b/src/webapp/layout/Main.tsx
@@ -21,33 +21,41 @@ export function Main({ routes, children }: Props) {
   }, [isSmallScreen]);
   return (
     <Container>
-      <Burger
-        opened={hamburgerOpen}
-        onClick={() => setHamburgerOpen(!hamburgerOpen)}
-      />
+      <BurgerWrapper>
+        <MantineBurger
+          size="sm"
+          opened={hamburgerOpen}
+          onClick={() => setHamburgerOpen(!hamburgerOpen)}
+        />
+      </BurgerWrapper>
       {(!isSmallScreen || hamburgerOpen) && (
         <Navbar onItemClick={() => setHamburgerOpen(false)} routes={routes} />
       )}
+      {hamburgerOpen && <Overlay />}
       <MainContent>{children}</MainContent>
     </Container>
   );
 }
-
-const Burger = styled(MantineBurger)({
+const BurgerWrapper = styled.div({
   display: "none",
   "@media (max-width: 960px)": {
-    zIndex: 100,
+    border: `1px solid #d9d9d9`,
+    backgroundColor: "#fff",
+    borderRadius: "8px",
+    boxShadow: "0px 2px 8px rgba(0, 0, 0, 0.06)",
+    zIndex: 2000,
     position: "absolute",
-    top: "24px",
-    right: "24px",
+    top: "28px",
+    right: "16px",
     display: "flex",
     alignItems: "center",
     justifyContent: "flex-end",
-    padding: "0px",
+    padding: "2px",
   },
 });
 
 const Container = styled.div`
+  position: relative;
   display: grid;
   grid-template-columns: auto 1fr;
   grid-template-rows: auto 1fr;
@@ -58,7 +66,17 @@ const Container = styled.div`
     "Menu Main";
   min-height: 100vh;
 `;
+
 const MainContent = styled.main`
   grid-area: Main;
   overflow: hidden;
+`;
+
+const Overlay = styled.div`
+  inset: 0px;
+  z-index: 1074;
+  position: absolute;
+  background-color: rgba(0, 0, 0, 0.5);
+  opacity: 1;
+  transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 `;

--- a/src/webapp/layout/Navbar.tsx
+++ b/src/webapp/layout/Navbar.tsx
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 import { css } from "@emotion/css";
-import { Code, Input } from "@mantine/core";
+import { Code, Input, MediaQuery } from "@mantine/core";
 import * as Accordion from "@radix-ui/react-accordion";
 import { ArrowDownIcon } from "../icons/ArrowDownIcon";
 import { SearchIcon } from "../icons/SearchIcon";
@@ -10,9 +10,10 @@ import { NestedStoryRoute } from "../routeLoader";
 
 interface Props {
   routes: NestedStoryRoute;
+  onItemClick: () => void;
 }
 
-export function Navbar({ routes }: Props) {
+export function Navbar({ routes, onItemClick }: Props) {
   return (
     <Wrapper>
       <ScrollWrap>
@@ -24,7 +25,7 @@ export function Navbar({ routes }: Props) {
           <Title>NAVBAR_TITLE</Title>
         </TopWrap>
         <InnerWrapper>
-          <MenuItems routes={routes} />
+          <MenuItems routes={routes} onItemClick={onItemClick} />
         </InnerWrapper>
         <CodeWrapper>
           <Code style={{ marginLeft: 16 }}>
@@ -36,7 +37,7 @@ export function Navbar({ routes }: Props) {
   );
 }
 
-function MenuItems({ routes }: { routes: NestedStoryRoute }) {
+function MenuItems({ routes, onItemClick }: Props) {
   const {
     accordionValues,
     activeStoryUrl,
@@ -102,6 +103,7 @@ function MenuItems({ routes }: { routes: NestedStoryRoute }) {
                               activeLink={activeLink}
                             >
                               <MenuItem
+                                onClick={onItemClick}
                                 to={story.urlPath}
                                 style={{ padding: "10px 0 10px 28px" }}
                                 activeLink={activeLink}
@@ -123,6 +125,7 @@ function MenuItems({ routes }: { routes: NestedStoryRoute }) {
                         activeLink={activeLink}
                       >
                         <MenuItem
+                          onClick={onItemClick}
                           key={story.urlPath}
                           to={story.urlPath}
                           activeLink={activeStoryUrl === story.urlPath}
@@ -217,11 +220,16 @@ const AccordionIcon = styled(ArrowDownIcon)({
 });
 
 const Wrapper = styled.div({
+  zIndex: 150,
   gridArea: "Menu",
   backgroundColor: "white",
   borderRight: "1px solid #e9ecef",
   position: "relative",
   boxShadow: "inset -5px -26px 24px -2px rgb(0 0 0 / 8%)",
+  "@media (max-width: 960px)": {
+    position: "fixed",
+    left: "0",
+  },
 });
 
 const ScrollWrap = styled.div({

--- a/src/webapp/layout/Navbar.tsx
+++ b/src/webapp/layout/Navbar.tsx
@@ -220,7 +220,7 @@ const AccordionIcon = styled(ArrowDownIcon)({
 });
 
 const Wrapper = styled.div({
-  zIndex: 150,
+  zIndex: 1075,
   gridArea: "Menu",
   backgroundColor: "white",
   borderRight: "1px solid #e9ecef",

--- a/src/webapp/layout/Navbar.tsx
+++ b/src/webapp/layout/Navbar.tsx
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 import { css } from "@emotion/css";
-import { Code, Input, MediaQuery } from "@mantine/core";
+import { Code, Input } from "@mantine/core";
 import * as Accordion from "@radix-ui/react-accordion";
 import { ArrowDownIcon } from "../icons/ArrowDownIcon";
 import { SearchIcon } from "../icons/SearchIcon";

--- a/src/webapp/layout/story/ActionOutput.tsx
+++ b/src/webapp/layout/story/ActionOutput.tsx
@@ -1,9 +1,10 @@
-import { Code } from '@mantine/core';
-import { observer } from 'mobx-react-lite';
-import type { ActionOutput as Outputs } from './useActionOutput';
+import styled from "@emotion/styled";
+import { Code } from "@mantine/core";
+import { observer } from "mobx-react-lite";
+import type { ActionOutput as Outputs } from "./useActionOutput";
 
 interface Props {
-  outputs: Outputs['outputs'];
+  outputs: Outputs["outputs"];
 }
 
 export const ActionOutput = observer(({ outputs }: Props) => {
@@ -11,26 +12,28 @@ export const ActionOutput = observer(({ outputs }: Props) => {
     return null;
   }
   return (
-    <Code block>
-      {outputs
-        .map(
-          output =>
-            (output.name ? `${output.name}: ` : '') +
-            output.args.map(a => prettyPrintObject(a)).join(', ')
-        )
-        .join('\n')}
-    </Code>
+    <Wrapper>
+      <Code block>
+        {outputs
+          .map(
+            (output) =>
+              (output.name ? `${output.name}: ` : "") +
+              output.args.map((a) => prettyPrintObject(a)).join(", ")
+          )
+          .join("\n")}
+      </Code>
+    </Wrapper>
   );
 });
 
 function prettyPrintObject(obj: any): string {
   if (obj instanceof FileList) {
     return `[ ${Array.from(obj)
-      .map(f => f.name)
-      .join(', ')} ]`;
-  } else if (obj.type === 'click') {
+      .map((f) => f.name)
+      .join(", ")} ]`;
+  } else if (obj.type === "click") {
     return `(click event) pageX: ${obj.pageX}, pageY: ${obj.pageX}`;
-  } else if (typeof obj === 'object') {
+  } else if (typeof obj === "object") {
     try {
       return JSON.stringify(obj);
     } catch (error) {
@@ -39,3 +42,7 @@ function prettyPrintObject(obj: any): string {
   }
   return String(obj);
 }
+
+const Wrapper = styled("div")({
+  marginTop: "12px",
+});

--- a/src/webapp/layout/story/CodeTemplate.tsx
+++ b/src/webapp/layout/story/CodeTemplate.tsx
@@ -1,19 +1,19 @@
-import { Prism } from '@mantine/prism';
-import { observer } from 'mobx-react-lite';
-import { CodeTemplateFn } from '../../../types';
-import { Control } from './control/useControl';
-import { childrenToString, propsToObject } from './propsToObject';
+import { Prism } from "@mantine/prism";
+import { observer } from "mobx-react-lite";
+import { CodeTemplateFn } from "../../../types";
+import { Control } from "./control/useControl";
+import { childrenToString, propsToObject } from "./propsToObject";
 
 interface Props {
   codeTemplate: Exclude<CodeTemplateFn, undefined>;
   controls: Control;
 }
 
-export const CodeTamplete = observer(({ codeTemplate, controls }: Props) => {
+export const CodeTemplate = observer(({ codeTemplate, controls }: Props) => {
   const props = propsToObject(Object.values(controls.state));
   return (
     <Prism language="tsx">
-      {codeTemplate(props, childrenToString(controls.state['children']))}
+      {codeTemplate(props, childrenToString(controls.state["children"]))}
     </Prism>
   );
 });

--- a/src/webapp/layout/story/Story.tsx
+++ b/src/webapp/layout/story/Story.tsx
@@ -4,7 +4,7 @@ import { observer } from "mobx-react-lite";
 import { Story } from "../../../types";
 import { Markdown } from "./atom/Markdown";
 import { ActionOutput } from "./ActionOutput";
-import { CodeTamplete } from "./CodeTemplate";
+import { CodeTemplate } from "./CodeTemplate";
 import { Controls } from "./control/Controls";
 import { useControl } from "./control/useControl";
 import { useIsDarkMode } from "./control/useIsDarkMode";
@@ -57,7 +57,7 @@ export const StoryComponent = observer(({ story }: { story: Story }) => {
             </ControlsWrapper>
           </Configurator>
           {story.codeTemplate && (
-            <CodeTamplete
+            <CodeTemplate
               codeTemplate={story.codeTemplate}
               controls={controls}
             />
@@ -74,18 +74,21 @@ const StoryTitle = styled(Title)`
   margin-bottom: 12px !important;
 `;
 
-const Wrapper = styled.div`
-  margin-top: 12px;
-  margin-bottom: 36px;
-`;
+const Wrapper = styled("div")({
+  marginTop: "12px",
+  marginBottom: "36px",
+});
 
-const Configurator = styled.div`
-  border: 1px solid #f1f3f5;
-  display: flex;
-  max-width: 100%;
-  border-top-left-radius: 4px;
-  border-top-right-radius: 4px;
-`;
+const Configurator = styled("div")({
+  border: "1px solid #f1f3f5",
+  display: "flex",
+  maxWidth: "100%",
+  borderTopLeftRadius: "4px",
+  borderTopRightRadius: "4px",
+  "@media (max-width: 960px)": {
+    flexDirection: "column",
+  },
+});
 
 const Prewview = styled.div`
   flex: 1;
@@ -93,12 +96,17 @@ const Prewview = styled.div`
   background: rgb(255, 255, 255);
 `;
 
-const ControlsWrapper = styled.div`
-  width: 250px;
-  padding: 16px;
-  box-sizing: border-box;
-  border-left: 1px solid #f1f3f5;
-`;
+const ControlsWrapper = styled("div")({
+  width: "250px",
+  padding: "16px",
+  boxSizing: "border-box",
+  borderLeft: "1px solid #f1f3f5",
+  "@media (max-width: 960px)": {
+    width: "100%",
+    borderLeft: "none",
+    borderTop: "1px solid #f1f3f5",
+  },
+});
 
 const SectionAnchor: React.FC<{ id: string; children?: React.ReactNode }> = ({
   id,

--- a/src/webapp/layout/story/StoryHeader.tsx
+++ b/src/webapp/layout/story/StoryHeader.tsx
@@ -1,15 +1,15 @@
-import React from 'react';
-import styled from '@emotion/styled';
-import { StoryHeader as StoryHeaderProps } from '../../../types';
-import { StoryHeaderButton } from './story-button/StoryButton';
-import { Body, Display } from './atom/typo';
+import React from "react";
+import styled from "@emotion/styled";
+import { StoryHeader as StoryHeaderProps } from "../../../types";
+import { StoryHeaderButton } from "./story-button/StoryButton";
+import { Body, Display } from "./atom/typo";
 
 export const StoryHeader: React.FC<StoryHeaderProps> = ({
   title,
   description,
   storyButtons,
 }) => {
-  const isDescriptionComponent = typeof description !== 'string';
+  const isDescriptionComponent = typeof description !== "string";
   return (
     <div>
       <HeaderWrapper>
@@ -20,11 +20,10 @@ export const StoryHeader: React.FC<StoryHeaderProps> = ({
           ) : (
             <HeaderDescription>{description}</HeaderDescription>
           )}
-          <div style={{ marginBottom: 32 }} />
           <ButtonWrapper>
             {storyButtons &&
               storyButtons.map(
-                button =>
+                (button) =>
                   button.url && (
                     <React.Fragment key={button.type}>
                       <StoryHeaderButton type={button.type} url={button.url} />
@@ -33,44 +32,57 @@ export const StoryHeader: React.FC<StoryHeaderProps> = ({
                   )
               )}
           </ButtonWrapper>
-          <div style={{ marginBottom: 66 }} />
         </HeaderContent>
       </HeaderWrapper>
     </div>
   );
 };
 
-const HeaderWrapper = styled('div')({
-  position: 'relative',
-  display: 'flex',
-  justifyContent: 'center',
-  borderBottom: '1px solid #EEEE',
+const HeaderWrapper = styled("div")({
+  position: "relative",
+  display: "flex",
+  justifyContent: "center",
+  borderBottom: "1px solid #EEEE",
   background:
-    'linear-gradient(0deg, rgba(0, 0, 0, 0.03) 0%, rgba(255, 255, 255, 0) 100%)',
+    "linear-gradient(0deg, rgba(0, 0, 0, 0.03) 0%, rgba(255, 255, 255, 0) 100%)",
 });
 
-const HeaderContent = styled('div')({
-  paddingTop: '56px',
-  paddingLeft: '40px',
-  paddingRight: '40px',
+const HeaderContent = styled("div")({
+  paddingTop: "56px",
+  paddingLeft: "40px",
+  paddingRight: "40px",
   minWidth: 300,
   maxWidth: 1280,
   flex: 1,
-  marginTop: '20px',
+  "@media (max-width: 960px)": {
+    paddingTop: "20px",
+    paddingLeft: "20px",
+    paddingRight: "20px",
+  },
 });
 
 const HeaderTitle = styled(Display)({
-  fontSize: '3rem',
-  marginBottom: '24px',
+  fontSize: "3rem",
+  marginBottom: "24px",
+  "@media (max-width: 960px)": {
+    maxWidth: "230px",
+    fontSize: "2rem",
+    overflowWrap: "break-word",
+  },
 });
 
 const HeaderDescription = styled(Body)({
-  fontSize: '1.2rem',
-  lineHeight: '1.4',
-  maxWidth: '600px',
-  color: '#000',
+  fontSize: "1.2rem",
+  lineHeight: "1.4",
+  maxWidth: "600px",
+  color: "#000",
+  marginBottom: "32px",
 });
 
-const ButtonWrapper = styled('div')({
-  display: 'flex',
+const ButtonWrapper = styled("div")({
+  display: "flex",
+  marginBottom: "42px",
+  "@media (max-width: 960px)": {
+    marginBottom: "32px",
+  },
 });

--- a/src/webapp/layout/story/story-button/StoryButton.story.tsx
+++ b/src/webapp/layout/story/story-button/StoryButton.story.tsx
@@ -1,32 +1,37 @@
-import { Story } from '../../../../public';
-import { StoryHeaderButton } from './StoryButton';
+import { Story } from "../../../../public";
+import { StoryHeaderButton } from "./StoryButton";
 
 export const story: Story = {
   header: {
-    title: 'Story button',
-    description: 'Buttons to use for external resources'
+    title: "Story button",
+    description: "Buttons to use for external resources",
   },
   stories: [
     {
-      name: 'Github',
+      name: "Github",
       center: true,
       render() {
-        return <StoryHeaderButton type="github" url="https://github.com" />
-      }
+        return <StoryHeaderButton type="github" url="https://github.com" />;
+      },
     },
     {
-      name: 'Figma',
+      name: "Figma",
       center: true,
       render() {
-        return <StoryHeaderButton type="figma" url="https://figma.com" />
-      }
+        return <StoryHeaderButton type="figma" url="https://figma.com" />;
+      },
     },
     {
-      name: 'Kivra Design System',
+      name: "Kivra Design System",
       center: true,
       render() {
-        return <StoryHeaderButton type="designsystem" url="https://design.kivra.com/" />
-      }
+        return (
+          <StoryHeaderButton
+            type="designsystem"
+            url="https://design.kivra.com/"
+          />
+        );
+      },
     },
-  ]
-}
+  ],
+};

--- a/src/webapp/layout/story/story-button/StoryButton.tsx
+++ b/src/webapp/layout/story/story-button/StoryButton.tsx
@@ -1,14 +1,15 @@
-import React from 'react';
-import styled from '@emotion/styled';
-import { Body } from '../atom/typo';
+import React from "react";
+import styled from "@emotion/styled";
+import { Body } from "../atom/typo";
+import { MediaQuery } from "@mantine/core";
 
 export interface Props {
-  type: 'github' | 'figma' | 'designsystem';
+  type: "github" | "figma" | "designsystem";
   url: string;
 }
 
 export const StoryHeaderButton: React.FC<Props> = ({ type, url }) => {
-  if (type === 'github') {
+  if (type === "github") {
     return (
       <StoryButton
         url={url}
@@ -17,7 +18,7 @@ export const StoryHeaderButton: React.FC<Props> = ({ type, url }) => {
         description="GitHub"
       />
     );
-  } else if (type === 'designsystem') {
+  } else if (type === "designsystem") {
     return (
       <StoryButton
         url={url}
@@ -52,46 +53,56 @@ const StoryButton = ({
   return (
     <ButtonWrapper href={url} target="_blank" rel="noopener noreferrer">
       <ButtonImage src={imgSrc} />
-      <div style={{ marginRight: 12 }} />
-      <ButtonText>
-        <Body color="$text-primary">{title}</Body>
-        <Body size="small" color="$text-secondary">
-          {description}
-        </Body>
-      </ButtonText>
+      <MediaQuery query="(max-width: 960px)" styles={{ display: "none" }}>
+        <div>
+          <ButtonText>
+            <Body color="$text-primary">{title}</Body>
+            <Body size="small" color="$text-secondary">
+              {description}
+            </Body>
+          </ButtonText>
+        </div>
+      </MediaQuery>
     </ButtonWrapper>
   );
 };
 
-const ButtonImage = styled('img')({
-  borderRadius: '8px',
-  width: '40px',
-  height: '40px',
+const ButtonImage = styled("img")({
+  borderRadius: "8px",
+  width: "40px",
+  height: "40px",
+  marginRight: 12,
+  "@media (max-width: 960px)": {
+    marginRight: 0,
+  },
 });
 
-const ButtonText = styled('div')({
-  borderRadius: '8px',
-  display: 'flex',
-  flexDirection: 'column',
+const ButtonText = styled("div")({
+  borderRadius: "8px",
+  display: "flex",
+  flexDirection: "column",
 });
 
-const ButtonWrapper = styled('a')({
-  textDecoration: 'none',
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'space-between',
+const ButtonWrapper = styled("a")({
+  textDecoration: "none",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "space-between",
   border: `1px solid #d9d9d9`,
-  backgroundColor: '#fff',
-  borderRadius: '8px',
-  boxShadow: '0px 2px 8px rgba(0, 0, 0, 0.06)',
+  backgroundColor: "#fff",
+  borderRadius: "8px",
+  boxShadow: "0px 2px 8px rgba(0, 0, 0, 0.06)",
   paddingLeft: 12,
   paddingRight: 20,
-  height: '56px',
-  transition: 'transform 0.25s cubic-bezier(0.35, 0.35, 0.58, 1)',
-  '&:hover': {
-    cursor: 'pointer',
-    boxShadow: '0px 2px 8px rgba(0, 0, 0, 0.06)',
-    transform: 'translate3d(0, -2px, 0)',
-    backgroundColor: '#ffffff',
+  height: "56px",
+  transition: "transform 0.25s cubic-bezier(0.35, 0.35, 0.58, 1)",
+  "&:hover": {
+    cursor: "pointer",
+    boxShadow: "0px 2px 8px rgba(0, 0, 0, 0.06)",
+    transform: "translate3d(0, -2px, 0)",
+    backgroundColor: "#ffffff",
+  },
+  "@media (max-width: 960px)": {
+    paddingRight: 12,
   },
 });


### PR DESCRIPTION
Updated the mobile view. This required several minor tweaks to some components.

Please **note** that since we NOW hide the navbar as default when on mobile view. This means that our start screen when viewing from a mobile device will look like a white screen with only a hamburger menu in the top right corner. This isn't something we should fix in this pr. We should edit `/`, (maybe add some text) this would fix that "problem".

Feel free to pull the branch and try it out locally.

**Start screen**:
![image](https://user-images.githubusercontent.com/62878534/226667005-ef8a53c0-9eef-49a1-a3df-5f2c495a44ed.png)

**New story look on mobile**:
![Screenshot 2023-03-21 at 16 50 47](https://user-images.githubusercontent.com/62878534/226665825-9e33fd20-1c0b-4475-87b4-bd69d6df7c3f.png)

https://user-images.githubusercontent.com/62878534/226665860-203726c4-6724-4779-a1f9-45fed64d9dd5.mov

