### PR TITLE
fix: collapsable code snippet

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -52,6 +52,7 @@ export interface Story {
   type?: "fullsize" | "configurator";
   center?: boolean;
   information?: string;
+  codeTemplateExpanded?: boolean;
   codeTemplate?: CodeTemplateFn;
   render?: (
     controls: ReturnType<

--- a/src/webapp/layout/story/Story.tsx
+++ b/src/webapp/layout/story/Story.tsx
@@ -42,6 +42,11 @@ export const StoryComponent = observer(({ story }: { story: Story }) => {
     toggleCodeSnippet();
   };
 
+  let codeTemplateSource = null;
+  if (story.codeTemplate) {
+    codeTemplateSource = story.codeTemplate.toString().trim();
+  }
+
   return (
     <Wrapper>
       <SectionAnchor id={sectionId}>
@@ -73,38 +78,43 @@ export const StoryComponent = observer(({ story }: { story: Story }) => {
               />
             </ControlsWrapper>
           </Configurator>
-          {story.codeTemplate && (
-            <>
-              <Button
-                leftIcon={<ArrowDownIcon />}
-                variant="default"
-                onClick={handleClick}
-                styles={() => ({
-                  root: {
-                    color: "gray",
-                    margin: "20px 0",
-                  },
-                  leftIcon: {
-                    transform: opened ? "rotate(180deg)" : "rotate(0deg)",
-                    transition: "transform 0.3s ease-in-out",
-                  },
-                })}
-              >
-                {opened ? "Hide code example" : "Show code example"}
-              </Button>
-              <Collapse
-                in={opened}
-                transitionDuration={300}
-                transitionTimingFunction="linear"
-              >
-                <CodeTemplate
-                  codeTemplate={story.codeTemplate}
-                  controls={controls}
-                />
-              </Collapse>
-            </>
-          )}
-          <ActionOutput outputs={outputs} />
+          {story.codeTemplate &&
+            (story.codeTemplateExpanded ? (
+              <>
+                <Button
+                  leftIcon={<ArrowDownIcon />}
+                  variant="default"
+                  onClick={handleClick}
+                  styles={() => ({
+                    root: {
+                      color: "gray",
+                      margin: "20px 0",
+                    },
+                    leftIcon: {
+                      transform: opened ? "rotate(180deg)" : "rotate(0deg)",
+                      transition: "transform 0.3s ease-in-out",
+                    },
+                  })}
+                >
+                  {opened ? "Hide code example" : "Show code example"}
+                </Button>
+                <Collapse
+                  in={opened}
+                  transitionDuration={300}
+                  transitionTimingFunction="linear"
+                >
+                  <CodeTemplate
+                    codeTemplate={story.codeTemplate}
+                    controls={controls}
+                  />
+                </Collapse>
+              </>
+            ) : (
+              <CodeTemplate
+                codeTemplate={story.codeTemplate}
+                controls={controls}
+              />
+            ))}
         </>
       )}
     </Wrapper>

--- a/src/webapp/layout/story/Story.tsx
+++ b/src/webapp/layout/story/Story.tsx
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { Center, Title } from "@mantine/core";
+import { Center, Title, Button, Collapse } from "@mantine/core";
 import { observer } from "mobx-react-lite";
 import { Story } from "../../../types";
 import { Markdown } from "./atom/Markdown";
@@ -10,6 +10,8 @@ import { useControl } from "./control/useControl";
 import { useIsDarkMode } from "./control/useIsDarkMode";
 import { DefaultComponentWrapper } from "./DefaultComponentWrapper";
 import { useActionOutput } from "./useActionOutput";
+import { useState } from "react";
+import { ArrowDownIcon } from "../../icons/ArrowDownIcon";
 
 export const StoryComponent = observer(({ story }: { story: Story }) => {
   const controls = useControl();
@@ -29,6 +31,16 @@ export const StoryComponent = observer(({ story }: { story: Story }) => {
   }
 
   const sectionId = encodeURIComponent(story?.name ?? "");
+
+  const [opened, setOpen] = useState(false);
+
+  const toggleCodeSnippet = () => {
+    setOpen((prevOpened) => !prevOpened);
+  };
+
+  const handleClick = () => {
+    toggleCodeSnippet();
+  };
 
   return (
     <Wrapper>
@@ -62,10 +74,35 @@ export const StoryComponent = observer(({ story }: { story: Story }) => {
             </ControlsWrapper>
           </Configurator>
           {story.codeTemplate && (
-            <CodeTemplate
-              codeTemplate={story.codeTemplate}
-              controls={controls}
-            />
+            <>
+              <Button
+                leftIcon={<ArrowDownIcon />}
+                variant="default"
+                onClick={handleClick}
+                styles={() => ({
+                  root: {
+                    color: "gray",
+                    margin: "20px 0",
+                  },
+                  leftIcon: {
+                    transform: opened ? "rotate(180deg)" : "rotate(0deg)",
+                    transition: "transform 0.3s ease-in-out",
+                  },
+                })}
+              >
+                {opened ? "Hide code example" : "Show code example"}
+              </Button>
+              <Collapse
+                in={opened}
+                transitionDuration={300}
+                transitionTimingFunction="linear"
+              >
+                <CodeTemplate
+                  codeTemplate={story.codeTemplate}
+                  controls={controls}
+                />
+              </Collapse>
+            </>
           )}
           <ActionOutput outputs={outputs} />
         </>

--- a/src/webapp/layout/story/story-button/StoryButton.story.tsx
+++ b/src/webapp/layout/story/story-button/StoryButton.story.tsx
@@ -42,6 +42,7 @@ export const story: Story = {
       codeTemplate: (props) => `
       <StoryHeaderButton${props}></StoryHeaderButton>
         `,
+      codeTemplateExpanded: false,
       render({ segment, text }) {
         const type = segment({
           name: "type",

--- a/src/webapp/layout/story/story-button/StoryButton.story.tsx
+++ b/src/webapp/layout/story/story-button/StoryButton.story.tsx
@@ -24,11 +24,44 @@ export const story: Story = {
     {
       name: "Kivra Design System",
       center: true,
+
       render() {
         return (
           <StoryHeaderButton
             type="designsystem"
             url="https://design.kivra.com/"
+          />
+        );
+      },
+    },
+    {
+      name: "Story Button",
+      center: true,
+      information:
+        "This is just an example how to use `<StoryHeaderButton />`s props. <br/>In this example also implemented show/hide code snippet that is possible to use in stories with `codeTemplate` function.",
+      codeTemplate: (props) => `
+      <StoryHeaderButton${props}></StoryHeaderButton>
+        `,
+      render({ segment, text }) {
+        const type = segment({
+          name: "type",
+          value: "designsystem",
+          options: [
+            ["designsystem", "designsystem"],
+            ["github", "github"],
+            ["figma", "figmaa"],
+          ],
+          showAs: "select",
+        });
+        return (
+          <StoryHeaderButton
+            type={type}
+            url={text({
+              name: "url",
+              value: "https://",
+              defaultValue: "https://design.kivra.com/",
+              description: "Always start with https://",
+            })}
           />
         );
       },


### PR DESCRIPTION
Just added this by using already existing library [Mentine](https://v3.mantine.dev/core/collapse/) 
Im not sure if this was exactly what you where looking for, so please come with input.

Added `codeTemplateExpanded` as optional. If that is set to true it will look like this:


https://github.com/kivra/toybox/assets/89391661/a725400f-a44a-4b73-8453-32d804c240d4
